### PR TITLE
#45-remove-redundant-code-from-tests

### DIFF
--- a/feature/feature-detail/src/test/java/com/example/feature_detail/DetailViewModelTest.kt
+++ b/feature/feature-detail/src/test/java/com/example/feature_detail/DetailViewModelTest.kt
@@ -11,11 +11,9 @@ import com.example.testing.MainDispatcherRule
 import com.example.testing.shouldBeEqualTo
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.impl.annotations.RelaxedMockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -42,14 +40,14 @@ class DetailViewModelTest {
     }
 
     @Test
-    fun whenObjectIdIsNotPassed_showUnknownError() = runTest {
+    fun whenObjectIdIsNotPassed_showUnknownError() {
         viewModel = createViewModel()
 
         viewModel.uiState.value.isUnknownError shouldBeEqualTo true
     }
 
     @Test
-    fun whenObjectIdIsPassed_objectIdIsSet() = runTest {
+    fun whenObjectIdIsPassed_objectIdIsSet() {
         viewModel = createViewModel(5)
 
         viewModel.uiState.value.isUnknownError shouldBeEqualTo false
@@ -57,7 +55,7 @@ class DetailViewModelTest {
     }
 
     @Test
-    fun whenObjectIdIsPassed_objectDetailIsReceived() = runTest {
+    fun whenObjectIdIsPassed_objectDetailIsReceived() {
         val testCase = ObjectDetail(
             name = "some object",
             imageUrl = null,
@@ -82,8 +80,7 @@ class DetailViewModelTest {
     }
 
     @Test
-    fun onTryAgain_getObjectDetailIsCalledAgain() = runTest {
-        coJustRun { getObjectDetailUseCase(any()) }
+    fun onTryAgain_getObjectDetailIsCalledAgain() {
         viewModel = createViewModel(5)
 
         viewModel.submitAction(TryAgain)

--- a/feature/feature-search/src/test/java/com/example/feature_search/SearchViewModelTest.kt
+++ b/feature/feature-search/src/test/java/com/example/feature_search/SearchViewModelTest.kt
@@ -7,10 +7,11 @@ import com.example.feature_search.search.SearchAction.OnUpdateTextField
 import com.example.feature_search.search.SearchViewModel
 import com.example.testing.MainDispatcherRule
 import com.example.testing.shouldBeEqualTo
+import io.mockk.Called
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -29,7 +30,7 @@ class SearchViewModelTest {
     @JvmField
     val instantExecutorRule = InstantTaskExecutorRule()
 
-    @RelaxedMockK
+    @MockK
     lateinit var searchObjectsUseCase: SearchObjectsUseCase
 
     private lateinit var viewModel: SearchViewModel
@@ -59,13 +60,13 @@ class SearchViewModelTest {
         viewModel.uiState.value.objectIds shouldBeEqualTo listOf()
         viewModel.uiState.value.isSearchLoading shouldBeEqualTo false
 
-        coVerify(exactly = 0) {
-            searchObjectsUseCase(any())
+        coVerify {
+            searchObjectsUseCase wasNot Called
         }
     }
 
     @Test
-    fun whenTextFieldIsValid_objectIdsAreEmptyBeforeDelay() = runTest {
+    fun whenTextFieldIsValid_objectIdsAreEmptyBeforeDelay() {
         coEvery { searchObjectsUseCase(any()) } returns SearchObjects(listOf(1, 2, 3))
         viewModel = createViewModel()
 
@@ -79,8 +80,8 @@ class SearchViewModelTest {
         viewModel.uiState.value.objectIds shouldBeEqualTo listOf()
         viewModel.uiState.value.isSearchLoading shouldBeEqualTo true
 
-        coVerify(exactly = 0) {
-            searchObjectsUseCase("flower")
+        coVerify {
+            searchObjectsUseCase wasNot Called
         }
     }
 


### PR DESCRIPTION
- replace relaxedMockk with Mockk
- remove unnecessary runTest